### PR TITLE
fix wasmx store key

### DIFF
--- a/injective-chain/app/app.go
+++ b/injective-chain/app/app.go
@@ -485,7 +485,7 @@ func NewInjectiveApp(
 
 	app.WasmxKeeper = wasmxkeeper.NewKeeper(
 		appCodec,
-		keys[auctiontypes.StoreKey],
+		keys[wasmxtypes.StoreKey],
 		app.GetSubspace(wasmxtypes.ModuleName),
 		app.AccountKeeper,
 		app.BankKeeper,


### PR DESCRIPTION
Hello,

I noticed that the store key was not being instantiated with the wasmx store key but rather the auction store key. I am not sure if this is on purpose or not. Just ignore this PR if it was.

Vulnerability does not look critical because the store key prefix only overlap with the 0x01 prefix. Bids are stored with just 0x1 whereas contracts are stored with 0x01 + contract address, so it should not overlap at all. Although, this may enable other access control vulnerabilities that I am unaware of (or cause problems in the future).

Even if it is currently harmless, this is bad practice and probably should be changed.