### PR TITLE
Add MacOS install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ $ ./injectived.sh
 
 Voila! You have now successfully setup a full node on the Injective Chain.
 
-If you'd like to install injectived for toolchain use on MacOS, here are the steps:
+### Install for MacOS
 1. Build from source
-```bash
-git clone https://github.com/OpenDeFiFoundation/injective-core.git
-cd injective-core
-make install
-```
+   ```bash
+   git clone https://github.com/OpenDeFiFoundation/injective-core.git
+   cd injective-core
+   make install
+   ```
 
 2. update ``.zshrc`` - Add these lines to your ``~/.zshrc`` file:
    ```bash

--- a/README.md
+++ b/README.md
@@ -44,6 +44,32 @@ $ ./injectived.sh
 
 Voila! You have now successfully setup a full node on the Injective Chain.
 
+If you'd like to install injectived for toolchain use on MacOS, here are the steps:
+1. Build from source
+```bash
+git clone https://github.com/OpenDeFiFoundation/injective-core.git
+cd injective-core
+make install
+```
+
+2. update ``.zshrc`` - Add these lines to your ``~/.zshrc`` file:
+   ```bash
+   export GOPATH=$HOME/go
+   export PATH=$PATH:$(go env GOPATH)/bin
+   export GOPRIVATE=github.com/InjectiveLabs/injective-core
+   ```
+
+3. refresh your ``~/.zshrc`` file
+   ```bash
+   source ~/.zshrc
+   ```
+
+4. Test to make sure its working
+   ```bash
+   injectived version
+   ```
+
+
 ## Generating the module specification docs
 ```bash
 $ cd docs && yarn && yarn run serve


### PR DESCRIPTION
This PR adds full documentation about how to install Injectived on MacOS (apple silicon and intel) for uploading contracts to testnet as well as any other uses of injectived.

Fixes:
- add MacOS install documentation to Readme
- give instructions for .zshrc updates