### PR TITLE
refactor: replace the deprecated function in the ioutil package

### DIFF
--- a/cmd/peggo/util.go
+++ b/cmd/peggo/util.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -18,7 +17,7 @@ import (
 // readEnv is a special utility that reads `.env` file into actual environment variables
 // of the current app, similar to `dotenv` Node package.
 func readEnv() {
-	if envdata, _ := ioutil.ReadFile(".env"); len(envdata) > 0 {
+	if envdata, _ := os.ReadFile(".env"); len(envdata) > 0 {
 		s := bufio.NewScanner(bytes.NewReader(envdata))
 		for s.Scan() {
 			parts := strings.Split(s.Text(), "=")

--- a/peggo/orchestrator/ethereum/keystore/keycache.go
+++ b/peggo/orchestrator/ethereum/keystore/keycache.go
@@ -3,8 +3,8 @@ package keystore
 import (
 	"crypto/ecdsa"
 	"crypto/sha1"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"sync"
 
@@ -87,7 +87,7 @@ func (k *keyCache) PrivateKey(account common.Address, password string) (*ecdsa.P
 		path = strings.TrimPrefix(path, "keystore://")
 	}
 
-	keyJSON, err := ioutil.ReadFile(path)
+	keyJSON, err := os.ReadFile(path)
 	if err != nil {
 		err = errors.Wrap(err, "failed to load a file from keystore")
 		return nil, err

--- a/peggo/orchestrator/ethereum/keystore/keystore.go
+++ b/peggo/orchestrator/ethereum/keystore/keystore.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -98,7 +97,7 @@ func (ks *keyStore) forEachWallet(keystorePath string, fn func(spec *WalletSpec)
 			return filepath.SkipDir
 		}
 		var spec *WalletSpec
-		if data, err := ioutil.ReadFile(path); err != nil {
+		if data, err := os.ReadFile(path); err != nil {
 			return err
 		} else if err = json.Unmarshal(data, &spec); err != nil {
 			return err

--- a/peggo/orchestrator/pricefeed/coingecko.go
+++ b/peggo/orchestrator/pricefeed/coingecko.go
@@ -3,7 +3,6 @@ package pricefeed
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -104,7 +103,7 @@ func (cp *CoingeckoPriceFeed) QueryUSDPrice(erc20Contract common.Address) (float
 		return zeroPrice, errors.Wrapf(err, "failed to fetch price from %s", reqURL)
 	}
 
-	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if err != nil {
 		_ = resp.Body.Close()
 		metrics.ReportFuncError(cp.svcTags)

--- a/peggo/test/peggo/constants.go
+++ b/peggo/test/peggo/constants.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/ecdsa"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -88,7 +87,7 @@ func init() {
 // readEnv is a special utility that reads `.env` file into actual environment variables
 // of the current app, similar to `dotenv` Node package.
 func readEnv() {
-	if envdata, _ := ioutil.ReadFile(".env"); len(envdata) > 0 {
+	if envdata, _ := os.ReadFile(".env"); len(envdata) > 0 {
 		s := bufio.NewScanner(bytes.NewReader(envdata))
 		for s.Scan() {
 			parts := strings.Split(s.Text(), "=")


### PR DESCRIPTION
Starting from Go 1.16, some functions in the ioutil package have been deprecated. The Go team recommends quickly switching to methods from the os or io packages instead. 

More info can see: https://github.com/golang/go/issues/45557