### PR TITLE
docs: fix typos in Peggy params proto comments

### DIFF
--- a/proto/injective/peggy/v1/params.proto
+++ b/proto/injective/peggy/v1/params.proto
@@ -49,14 +49,14 @@ option go_package = "github.com/InjectiveLabs/injective-core/injective-chain/mod
 // target_batch_timeout:
 //
 // This is the 'target' value for when batches time out, this is a target
-// becuase Ethereum is a probabalistic chain and you can't say for sure what the
+// because Ethereum is a probabilistic chain and you can't say for sure what the
 // block frequency is ahead of time.
 //
 // average_block_time
 // average_ethereum_block_time
 //
 // These values are the average Cosmos block time and Ethereum block time
-// repsectively and they are used to copute what the target batch timeout is. It
+// respectively and they are used to compute what the target batch timeout is. It
 // is important that governance updates these in case of any major, prolonged
 // change in the time it takes to produce a block
 //
@@ -73,7 +73,7 @@ option go_package = "github.com/InjectiveLabs/injective-core/injective-chain/mod
 //
 // The unbond slashing valsets window is used to determine how many blocks after
 // starting to unbond a validator needs to continue signing blocks. The goal of
-// this paramater is that when a validator leaves the set, if their leaving
+// this parameter is that when a validator leaves the set, if their leaving
 // creates enough change in the validator set to justify an update they will
 // sign a validator set update for the Ethereum bridge that does not include
 // themselves. Allowing us to remove them from the Ethereum bridge and replace
@@ -86,7 +86,7 @@ option go_package = "github.com/InjectiveLabs/injective-core/injective-chain/mod
 // advised that chains use only Cosmos originated tokens, which the bridge
 // effectively mints on Ethereum. If you run out of the token you are using for
 // validator set rewards valset updates will fail and the bridge will be
-// vulnerable to highjacking. For these paramaters the zero values are special
+// vulnerable to hijacking. For these parameters the zero values are special
 // and indicate not to attempt any reward. This is the default for
 // bootstrapping.
 


### PR DESCRIPTION
## Summary
- Fix typo: "becuase" -> "because"
- Fix typo: "probabalistic" -> "probabilistic"
- Fix typo: "repsectively" -> "respectively"
- Fix typo: "copute" -> "compute"
- Fix typo: "paramater" -> "parameter"
- Fix typo: "highjacking" -> "hijacking"
- Fix typo: "paramaters" -> "parameters"

## Test plan
- [x] Comment-only changes in proto file, no functional changes