### PR TITLE
fix: correct typo in permissions wasm hook example comment

### DIFF
--- a/injective-chain/modules/permissions/wasm-hook-example/src/contract.rs
+++ b/injective-chain/modules/permissions/wasm-hook-example/src/contract.rs
@@ -111,7 +111,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 'd' => loop {
                     // for to_address that ends with 'd' invoke out of gas panic
                 },
-                _ => to_binary(&env.contract.address), // any other is successfull replace to_addr with contract_addr
+                _ => to_binary(&env.contract.address), // any other is successful replace to_addr with contract_addr
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix typo: "successfull" -> "successful"

## Test plan
- [x] Comment-only change, no functional changes